### PR TITLE
Fix Files new dialog layout

### DIFF
--- a/customizer/cnx-custom-theme/css/activities.css
+++ b/customizer/cnx-custom-theme/css/activities.css
@@ -5266,6 +5266,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/blogs.css
+++ b/customizer/cnx-custom-theme/css/blogs.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/communities.css
+++ b/customizer/cnx-custom-theme/css/communities.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/dogear.css
+++ b/customizer/cnx-custom-theme/css/dogear.css
@@ -5266,6 +5266,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/files.css
+++ b/customizer/cnx-custom-theme/css/files.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/forums.css
+++ b/customizer/cnx-custom-theme/css/forums.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/global.css
+++ b/customizer/cnx-custom-theme/css/global.css
@@ -30,6 +30,7 @@
   /*Component Imports*/
   /*Notificaiton panel full length*/
   /*For Files Tile view quick fix put this code somewhere more relevant once its done*/
+  /* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
   /*[id^="com_ibm_oneui_controls_MessageBox_"] {
   	.lotusMessageBody {
   		max-width: 500px !important;
@@ -5185,6 +5186,9 @@
 .ics-viewer label {
   font-weight: 500 !important;
   color: #595859 !important;
+}
+.ics-viewer div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, .ics-viewer div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, .ics-viewer div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
 }
 .ics-viewer :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;

--- a/customizer/cnx-custom-theme/css/home.css
+++ b/customizer/cnx-custom-theme/css/home.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/meetings.css
+++ b/customizer/cnx-custom-theme/css/meetings.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/metrics.css
+++ b/customizer/cnx-custom-theme/css/metrics.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/opensocial.css
+++ b/customizer/cnx-custom-theme/css/opensocial.css
@@ -5266,6 +5266,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/profiles.css
+++ b/customizer/cnx-custom-theme/css/profiles.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/search.css
+++ b/customizer/cnx-custom-theme/css/search.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/settings.css
+++ b/customizer/cnx-custom-theme/css/settings.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/surveys.css
+++ b/customizer/cnx-custom-theme/css/surveys.css
@@ -5266,6 +5266,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/css/wikis.css
+++ b/customizer/cnx-custom-theme/css/wikis.css
@@ -5267,6 +5267,11 @@ label {
   color: #595859 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby=create_pres_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_sheet_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td, div[aria-describedby=create_doc_in_ibm_docs_dec_div] .lotusFormTable tbody tr:nth-child(5) td {
+  width: 450px !important;
+}
+
 :not([id^=lconn_profiles_invite_InvitePanel_][id$=_networkInviteForm]) .lotusFormFieldRow td {
   display: block !important;
   margin: 0 !important;

--- a/customizer/cnx-custom-theme/scss/components/_form.scss
+++ b/customizer/cnx-custom-theme/scss/components/_form.scss
@@ -3,6 +3,13 @@ label {
 	color: $text-02 !important;
 }
 
+/* MKS 06/30/2021 Files - New Document/Presentation/Spreadsheet dialog layout */
+div[aria-describedby="create_pres_in_ibm_docs_dec_div"], div[aria-describedby="create_sheet_in_ibm_docs_dec_div"], div[aria-describedby="create_doc_in_ibm_docs_dec_div"]{
+    .lotusFormTable tbody tr:nth-child(5) td { 
+	    width: 450px !important;
+	}
+}
+
 :not([id^="lconn_profiles_invite_InvitePanel_"][id$="_networkInviteForm"]) .lotusFormFieldRow{
 	td {
 		display:block!important;


### PR DESCRIPTION
In Files, the dialogs for creating new documents, spreadsheets, and presentations display "Allow others to share these files?" in a narrow table cell. The fixed layout looks similar to this:
![image](https://user-images.githubusercontent.com/30048699/124176577-0e437080-da7d-11eb-824f-b54beb733cd8.png)

Check the fix here: https://connections.woodburn.digital/files/app#/