### PR TITLE
Teams chat profile bizcard using wrong email key

### DIFF
--- a/customizer/samples/microsoft-teams/Chat Integration/ms-teams-profile-bizcard.json
+++ b/customizer/samples/microsoft-teams/Chat Integration/ms-teams-profile-bizcard.json
@@ -26,7 +26,7 @@
             "payload": {
                 "url": "",
                 "text": "%nls:TeamsBizcardChat-Connections_text",
-                "href": "https://teams.microsoft.com/l/chat/0/0?users=${!emails}",
+                "href": "https://teams.microsoft.com/l/chat/0/0?users=${email}",
                 "locator": "chat",
                 "target": "TeamsChat"
             },


### PR DESCRIPTION
Please review.  emails is not a valid key that works, fixing to match other samples.