### PR TITLE
fix community files upload dialog

### DIFF
--- a/customizer/cnx-custom-theme/css/communities.css
+++ b/customizer/cnx-custom-theme/css/communities.css
@@ -13533,6 +13533,10 @@ body.catalog input[type=password] {
   box-shadow: none !important;
 }
 
+.lotusUploadFile .lotusDialog .lotusFormFieldRow td {
+  display: table-cell !important;
+}
+
 .lotusMain .lotusColLeft .lotusHeading {
   padding-left: 24px;
 }

--- a/customizer/cnx-custom-theme/scss/apps/communities/communitieslanding/_communitieslanding.scss
+++ b/customizer/cnx-custom-theme/scss/apps/communities/communitieslanding/_communitieslanding.scss
@@ -130,4 +130,11 @@ body.catalog input[type=password] {
   height: auto !important;
 }
 
+
 #icCatalogFilter {padding: 0 0 0 10px !important; line-height: 2rem !important; border-bottom: none !important; box-shadow: none !important}
+
+
+.lotusUploadFile .lotusDialog .lotusFormFieldRow td {
+  display: table-cell !important;
+}
+


### PR DESCRIPTION
The file drop area in the Community Files "Upload Files" dialog should look like the image below, not compressed horizontally and aligned left as it was previously.

![image](https://user-images.githubusercontent.com/30048699/132907314-7dfe97e8-3b51-47cc-9139-ebdeedc04466.png)
