### PR TITLE
fix community create warning

### DIFF
--- a/customizer/cnx-custom-theme/css/communities.css
+++ b/customizer/cnx-custom-theme/css/communities.css
@@ -13701,6 +13701,12 @@ body.catalog input[type=password] {
   display: none !important;
 }
 
+#internalOnlyPermanentWarning > div {
+  position: relative;
+  right: 585px;
+  width: 500px;
+}
+
 #selectCommForm #communityTypeAhead {
   padding-left: 2rem !important;
 }

--- a/customizer/cnx-custom-theme/scss/apps/communities/communitieslanding/_createnew.scss
+++ b/customizer/cnx-custom-theme/scss/apps/communities/communitieslanding/_createnew.scss
@@ -130,6 +130,13 @@
   }
 }
 
+// Issue on creating new Community github.com/hclcnx/cnx-custom-theme/issues/63 
+#internalOnlyPermanentWarning > div {
+    position: relative;
+    right: 585px;
+    width: 500px;
+}
+
 #selectCommForm {
   #communityTypeAhead {
     padding-left: 2rem !important;


### PR DESCRIPTION
When selecting an Open Community, the warning box about not being able to change that was off center. Testing done in Firefox and Chrome, box is now left-aligned.

Steps to check the fix:

Create New Community

Choose Public

Warning box about unable to change from Public afterwards is left aligned.

![image](https://user-images.githubusercontent.com/30048699/133612530-c6c3e62f-2513-467c-9a4e-708134f62635.png)
