### PR TITLE
Fix Tuesday display in repeating event picker

### DIFF
--- a/customizer/cnx-custom-theme/css/communities.css
+++ b/customizer/cnx-custom-theme/css/communities.css
@@ -10490,6 +10490,11 @@ div.recOptions {
   background: #FFF !important;
 }
 
+/* MKS CNXSERV-13772 repeat event daily display Tuesday */
+tr#calendar_event_editor_rec-recDaily td:nth-child(3) {
+  display: inline !important;
+}
+
 #body .lconnPickerSourceArea .headerSelector .checkbox {
   margin-top: 5px !important;
 }

--- a/customizer/cnx-custom-theme/scss/apps/communities/_calendarView.scss
+++ b/customizer/cnx-custom-theme/scss/apps/communities/_calendarView.scss
@@ -45,4 +45,7 @@
 
 div.recOptions { background: #FFF !important;}
 
-
+/* MKS CNXSERV-13772 repeat event daily display Tuesday */
+tr#calendar_event_editor_rec-recDaily td:nth-child(3) {
+    display:inline !important;
+  }


### PR DESCRIPTION
This fix makes "Tuesday" and the associated checkbox appear properly in the day picker in a repeating community event creation dialog:

![image](https://user-images.githubusercontent.com/30048699/165137786-ff86d6d5-bdd2-439f-b838-d1025bc99317.png)